### PR TITLE
fix rocket concurrency issues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ROCKET_PORT=$PORT ./target/release/rust-buildpack-example-rocket
+web: ROCKET_PORT=$PORT ROCKET_KEEP_ALIVE=0 ./target/release/rust-buildpack-example-rocket


### PR DESCRIPTION
When deployed, the current Rocket version (0.4) causes heroku H13 errors even under moderate load. See https://github.com/SergioBenitez/Rocket/issues/1268 for more details. Setting `is-alive` to 0 as recommended in https://github.com/SergioBenitez/Rocket/issues/1254 solves this issue, and should be set by default when deploying to production using Rocket with the heroku rust buildpack as in this example repo.

Solves https://github.com/emk/rust-buildpack-example-rocket/issues/3